### PR TITLE
Disable pointer-events in stars overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,7 @@
             width: 100%;
             height: 100%;
             overflow: hidden;
+            pointer-events: none;
         }
         #subtitle{
             color: paleturquoise;


### PR DESCRIPTION
Sem esse atributo, não dá pra clicar no áudio pra dar play porque o `#stars-container` fica por cima, [devido ao `position: fixed`](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context)